### PR TITLE
Allow changing KERNEL_DIR

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,12 +4,13 @@
 #
 
 KERNELRELEASE ?= $(shell uname -r)
+KERNEL_DIR    ?= /lib/modules/$(KERNELRELEASE)/build
 
 obj-m = apfs.o
 apfs-y = btree.o dir.o extents.o file.o inode.o key.o message.o \
 	 namei.o node.o object.o super.o symlink.o unicode.o xattr.o
 
 default:
-	make -C /lib/modules/$(KERNELRELEASE)/build M=$(shell pwd)
+	make -C $(KERNEL_DIR) M=$(shell pwd)
 clean:
-	make -C /lib/modules/$(KERNELRELEASE)/build M=$(shell pwd) clean
+	make -C $(KERNEL_DIR) M=$(shell pwd) clean


### PR DESCRIPTION
Allow building in a different directory.
This is useful on NixOS, where all software is stored under /nix.
As a nice side-effect, this change also reduces code duplication a little.

If this PR is accepted, I plan to propose two more small changes to the Makefile.