### PR TITLE
Simplify Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,12 +5,13 @@
 
 KERNELRELEASE ?= $(shell uname -r)
 KERNEL_DIR    ?= /lib/modules/$(KERNELRELEASE)/build
+PWD           := $(shell pwd)
 
 obj-m = apfs.o
 apfs-y = btree.o dir.o extents.o file.o inode.o key.o message.o \
 	 namei.o node.o object.o super.o symlink.o unicode.o xattr.o
 
 default:
-	make -C $(KERNEL_DIR) M=$(shell pwd)
+	make -C $(KERNEL_DIR) M=$(PWD)
 clean:
-	make -C $(KERNEL_DIR) M=$(shell pwd) clean
+	make -C $(KERNEL_DIR) M=$(PWD) clean


### PR DESCRIPTION
Replacing `$(PWD)` with `$$PWD` seems to also work. This would save the `PWD := $(shell pwd)` line but I think this breaks when the `PWD` variable isn't set when the makefile is executed.