### PR TITLE
Fix build for linux 5.12

### DIFF
--- a/inode.c
+++ b/inode.c
@@ -301,8 +301,14 @@ int apfs_getattr(struct vfsmount *mnt, struct dentry *dentry,
 
 #else /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0) */
 
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+int apfs_getattr(struct user_namespace *mnt_uerns, const struct path *path,
+		 struct kstat *stat,u32 request_mask, unsigned int query_flags)
+#else
 int apfs_getattr(const struct path *path, struct kstat *stat,
 		 u32 request_mask, unsigned int query_flags)
+#endif
+
 {
 	struct inode *inode = d_inode(path->dentry);
 	struct apfs_inode_info *ai = APFS_I(inode);
@@ -314,8 +320,11 @@ int apfs_getattr(const struct path *path, struct kstat *stat,
 		stat->attributes |= STATX_ATTR_COMPRESSED;
 
 	stat->attributes_mask |= STATX_ATTR_COMPRESSED;
-
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+	generic_fillattr(&init_user_ns, inode, stat);
+#else
 	generic_fillattr(inode, stat);
+#endif
 #if BITS_PER_LONG == 32
 	stat->ino = ai->i_ino;
 #endif /* BITS_PER_LONG == 32 */

--- a/inode.h
+++ b/inode.h
@@ -130,9 +130,15 @@ extern struct inode *apfs_iget(struct super_block *sb, u64 cnid);
 #if LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0) /* No statx yet... */
 extern int apfs_getattr(struct vfsmount *mnt, struct dentry *dentry,
 			struct kstat *stat);
+
+#else
+#if LINUX_VERSION_CODE >= KERNEL_VERSION(5, 12, 0)
+extern int apfs_getattr(struct user_namespace *mnt_uerns, const struct path *path,
+		 struct kstat *stat,u32 request_mask, unsigned int query_flags);
 #else
 extern int apfs_getattr(const struct path *path, struct kstat *stat,
-			u32 request_mask, unsigned int query_flags);
+		 u32 request_mask, unsigned int query_flags);
+#endif
 #endif /* LINUX_VERSION_CODE < KERNEL_VERSION(4, 11, 0) */
 
 #endif	/* _APFS_INODE_H */


### PR DESCRIPTION
Some functions seem to take user_namespace argument since 5.12. I followed this and fixed the build.
https://github.com/namjaejeon/linux-exfat-oot/blob/0e85284b46bddf107151a152bdc20de45faf07bb/file.c#L294-L328